### PR TITLE
[eclipse/xtext#1279] use orbit simrel alias directly

### DIFF
--- a/domainmodel/2.19.0/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/domainmodel/2.19.0/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -27,7 +27,7 @@
       <unit id="org.apache.commons.cli" version="1.2.0.v201404270220"/>
       <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
       <unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>

--- a/greetings-tycho/2.19.0-J11/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
+++ b/greetings-tycho/2.19.0-J11/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
@@ -32,7 +32,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>

--- a/greetings-tycho/2.19.0/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
+++ b/greetings-tycho/2.19.0/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
@@ -32,7 +32,7 @@
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 			<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
[eclipse/xtext#1279] use orbit simrel alias directly

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>