### PR TITLE
adapt tp for integ tests to newer emf version (2.20) required by Xtext 2.21

### DIFF
--- a/integrationtests/org.eclipse.xtext.integrationtests.target/org.eclipse.xtext.integrationtests.target.target
+++ b/integrationtests/org.eclipse.xtext.integrationtests.target/org.eclipse.xtext.integrationtests.target.target
@@ -53,7 +53,6 @@
 		<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <!--		<unit id="org.eclipse.xpand" version="0.0.0"/> 
 		<unit id="org.eclipse.xtend" version="0.0.0"/>
 		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/> 
@@ -61,6 +60,11 @@
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/releases/oxygen/201804111000"/>
+	</location>
+
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
adapt tp for integ tests to newer emf version (2.20) required by Xtext 2.21

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>