### PR TITLE
build java 8 against old target platform cause platforms strange java 11 transition

### DIFF
--- a/greetings-tycho/2.24.0/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
+++ b/greetings-tycho/2.24.0/org.xtext.example.mydsl.target/org.xtext.example.mydsl.target.target
@@ -8,7 +8,8 @@
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/releases/2020-12"/>
+			<!-- newer Eclipse versions need Java 11 to run the Maven Tycho build -->
+			<repository location="https://download.eclipse.org/releases/2020-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>


### PR DESCRIPTION
build java 8 against old target platform cause platforms strange java 11 transition

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>