### PR TITLE
Workaround for Java 8 problem with version ranges in emf and platform

### DIFF
--- a/greetings-tycho/2.26.0/org.xtext.example.mydsl/pom.xml
+++ b/greetings-tycho/2.26.0/org.xtext.example.mydsl/pom.xml
@@ -51,6 +51,16 @@
 						<groupId>org.eclipse.xtext</groupId>
 						<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
 						<version>${xtextVersion}</version>
+						<exclusions>
+							<exclusion>
+								<groupId>org.eclipse.platform</groupId>
+								<artifactId>org.eclipse.equinox.common</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>org.eclipse.platform</groupId>
+								<artifactId>org.eclipse.core.runtime</artifactId>
+							</exclusion>
+						</exclusions>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>


### PR DESCRIPTION
Workaround for Java 8 problem with version ranges in emf and platform
https://github.com/eclipse/xtext/issues/1976

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>