### PR TITLE
explicit transitive deps for xtext.xtext.generator

### DIFF
--- a/greetings-tycho/2.26.0/org.eclipse.xtext.xtext.generator.patched/pom.xml
+++ b/greetings-tycho/2.26.0/org.eclipse.xtext.xtext.generator.patched/pom.xml
@@ -1,0 +1,162 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.xtext</groupId>
+	<artifactId>org.eclipse.xtext.xtext.generator.patched</artifactId>
+	<version>2.26.0-SNAPSHOT</version>
+
+	<properties>
+		<xtextVersion>2.26.0-SNAPSHOT</xtextVersion>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.eclipse.xtext</groupId>
+				<artifactId>xtext-dev-bom</artifactId>
+				<version>${xtextVersion}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<!-- transitive dependencies of org.eclipse.xtext.xtext.generator -->
+
+		<!-- required by org.eclipse.core.runtime -->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.osgi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.jobs</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.registry</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.preferences</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.contenttype</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.app</artifactId>
+		</dependency>
+		<!-- required by org.eclipse.core.resources -->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.expressions</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.filesystem</artifactId>
+		</dependency>
+		<!-- required by org.eclipse.text -->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.commands</artifactId>
+		</dependency>
+		<!-- required by org.eclipse.jdt.core -->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.text</artifactId>
+		</dependency>
+		<!-- required by org.eclipse.debug.core -->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.variables</artifactId>
+		</dependency>
+		<!-- required by org.eclipse.jdt.launching -->
+		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.debug</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.debug.core</artifactId>
+		</dependency>
+		<!-- required by org.eclipse.emf.codegen -->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.runtime</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.resources</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.launching</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
+			<version>${xtextVersion}</version>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>codehaus-snapshots</id>
+			<name>disable dead 'Codehaus Snapshots' repository, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=481478</name>
+			<url>http://nexus.codehaus.org/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>sonatype-snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>codehaus-snapshots</id>
+			<name>disable dead 'Codehaus Snapshots' repository, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=481478</name>
+			<url>http://nexus.codehaus.org/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>sonatype-snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/greetings-tycho/2.26.0/org.xtext.example.mydsl/pom.xml
+++ b/greetings-tycho/2.26.0/org.xtext.example.mydsl/pom.xml
@@ -49,7 +49,7 @@
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>
-						<artifactId>org.eclipse.xtext.xtext.generator</artifactId>
+						<artifactId>org.eclipse.xtext.xtext.generator.patched</artifactId>
 						<version>${xtextVersion}</version>
 					</dependency>
 					<dependency>

--- a/scripts/greetings-tycho-2.26.sh
+++ b/scripts/greetings-tycho-2.26.sh
@@ -7,4 +7,6 @@ export PROFILES=-Pxtext_snapshots
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
+mvn -f org.eclipse.xtext.xtext.generator.patched/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES clean install
+
 mvn -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES -Dtycho.showEclipseLog=true clean install


### PR DESCRIPTION
This is another (the 4th) alternative possible solution for eclipse/xtext#1976 and it was anticipated in other PR https://github.com/itemis/xtext-reference-projects/pull/187.

The idea is that we (Xtext), relying on the BOM, list (i.e., pin) all the dependencies that are known to use version ranges so that we know we pin them once and for all (as soon as we update the BOM, everything will automatically be updated).

From my experiments, when running `exec-maven-plugin` the transitive dependency hell is only due to `org.eclipse.xtext.xtext.generator` because of its dependencies: `org.eclipse.emf.codegen` and `org.eclipse.emf.codegen.ecore`.
If we fix `org.eclipse.xtext.xtext.generator` under that respect then everything works. I had a look at the other POMs and using the m2e "Dependency Hierarchy" view, `org.eclipse.xtext.xtext.generator` is the only Maven artifact of ours (which is used in `exec-maven-plugin`) suffering from the transitive dependency hell: `org.eclipse.emf.mwe2.launch`, `org.eclipse.xtext.common.types` and `org.eclipse.xtext.xbase` are fine!

In this PR, which aims at recreating such a solution, I created the project `org.eclipse.xtext.xtext.generator.patched` that is now used in the example DSL for `exec-maven-plugin`. Basically `org.eclipse.xtext.xtext.generator.patched` depends on the original `org.eclipse.xtext.xtext.generator` and lists all the transitive dependencies of the above mentioned EMF dependencies (relying on our BOM).

In the script I simulate the final user experience by first installing such a project in the local Maven repository. Then, the standard build is executed (using `org.eclipse.xtext.xtext.generator.patched`).

Similar to https://github.com/itemis/xtext-reference-projects/pull/187:

This is a pure Maven solution, which does not interfere with the TP anyway.

I tested it locally and I verified that no additional Eclipse and EMF JARs are downloaded when running exec-maven-plugin. (what I've done is start from a clean .m2 repository, install first this `org.eclipse.xtext.xtext.generator.patched` and then build the Tycho example, verifying that no other Eclipse and EMF JAR are downloaded... it wasn't fun ;)

This solution will work without touching the MANIFEST, it only requires the POM of the DSL to be modified.

Note that this solution will give us (Xtext) full control...

OF COURSE, this PR is not meant to be merged, it's just to show a possible solution that will then require to patch the real `org.eclipse.xtext.xtext.generator`. With that respect, I seem to understand that our Maven POMs are actually generated by Gradle, aren't they? I guess this should be a problem since the build.gradle still can benefit from our BOM, can't it?

I can propose a PR for `org.eclipse.xtext.xtext.generator`.
