### PR TITLE
Run Maven build in batch mode to avoid cluttered logs

### DIFF
--- a/scripts/domainmodel-2.26.sh
+++ b/scripts/domainmodel-2.26.sh
@@ -7,4 +7,4 @@ export PROFILES=-Pxtext_snapshots
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES -Dtycho.showEclipseLog=true clean install
+mvn -B $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES -Dtycho.showEclipseLog=true clean install

--- a/scripts/greetings-maven-2.26-J11.sh
+++ b/scripts/greetings-maven-2.26-J11.sh
@@ -9,4 +9,4 @@ export PROFILES=-Ptycho_snapshots,xtext_snapshots
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES clean install
+mvn -B -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES clean install

--- a/scripts/greetings-maven-2.26.sh
+++ b/scripts/greetings-maven-2.26.sh
@@ -9,4 +9,4 @@ export PROFILES=-Ptycho_snapshots,xtext_snapshots
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES clean install
+mvn -B -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES clean install

--- a/scripts/greetings-tycho-2.26-J11.sh
+++ b/scripts/greetings-tycho-2.26-J11.sh
@@ -7,4 +7,4 @@ export PROFILES=-Pxtext_snapshots
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES -Dtycho.showEclipseLog=true clean install
+mvn -B -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES -Dtycho.showEclipseLog=true clean install

--- a/scripts/greetings-tycho-2.26.sh
+++ b/scripts/greetings-tycho-2.26.sh
@@ -7,4 +7,4 @@ export PROFILES=-Pxtext_snapshots
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES -Dtycho.showEclipseLog=true clean install
+mvn -B -f org.xtext.example.mydsl.parent/pom.xml $DISABLE_DOWNLOAD_PROGRESS $SETTINGS $PROFILES -Dtycho.showEclipseLog=true clean install

--- a/scripts/integrationtests-wizard.sh
+++ b/scripts/integrationtests-wizard.sh
@@ -4,4 +4,4 @@ TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-../}"
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn $DISABLE_DOWNLOAD_PROGRESS $SETTINGS -Dtycho.showEclipseLog=true clean install -Dtest=XtextNewProjectWizardTest
+mvn -B $DISABLE_DOWNLOAD_PROGRESS $SETTINGS -Dtycho.showEclipseLog=true clean install -Dtest=XtextNewProjectWizardTest

--- a/scripts/integrationtests-xtend-examples.sh
+++ b/scripts/integrationtests-xtend-examples.sh
@@ -6,4 +6,4 @@ TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-../}"
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn $DISABLE_DOWNLOAD_PROGRESS $SETTINGS -Dtycho.showEclipseLog=true clean install -Dtest=XtendExamplesTest
+mvn -B $DISABLE_DOWNLOAD_PROGRESS $SETTINGS -Dtycho.showEclipseLog=true clean install -Dtest=XtendExamplesTest

--- a/scripts/integrationtests-xtext-examples.sh
+++ b/scripts/integrationtests-xtext-examples.sh
@@ -4,4 +4,4 @@ TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-../}"
 export SETTINGS="-s $TRAVIS_BUILD_DIR/settings.xml"
 export DISABLE_DOWNLOAD_PROGRESS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn 
 
-mvn $DISABLE_DOWNLOAD_PROGRESS $SETTINGS -Dtycho.showEclipseLog=true clean install -Dtest=XtextExamplesTest
+mvn -B $DISABLE_DOWNLOAD_PROGRESS $SETTINGS -Dtycho.showEclipseLog=true clean install -Dtest=XtextExamplesTest


### PR DESCRIPTION
Run Maven build in batch mode to avoid cluttered logs
Fixes #191 
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>