### PR TITLE
[eclipse/xtext#2086] use gef classic instead of legacy draw2d + workaround for platform problem with commons.io

### DIFF
--- a/domainmodel/2.28.0/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/domainmodel/2.28.0/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -25,6 +25,7 @@
       <unit id="com.google.inject" version="5.0.1.v20210324-2015"/>
       <unit id="io.github.classgraph" version="4.8.138.v20211212-1642"/>
       <unit id="org.apache.commons.cli" version="1.4.0.v20200417-1444"/>
+      <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
       <unit id="org.apache.log4j" version="1.2.19.v20220208-1728"/>
       <unit id="org.apache.log4j.source" version="1.2.19.v20220208-1728"/>
       <unit id="org.aopalliance" version="1.0.0.v20220404-1927"/>
@@ -32,8 +33,8 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/2022-09"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>
-      <repository location="https://download.eclipse.org/tools/gef/updates/legacy/releases"/>
+      <unit id="org.eclipse.draw2d.feature.group" version="3.14.0.202206170857"/>
+      <repository location="https://download.eclipse.org/tools/gef/classic/releases/3.14.0/"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
[eclipse/xtext#2086] use gef classic instead of legacy draw2d + workaround for platform problem with commons.io